### PR TITLE
cascader: Add a 2nd parameter for change event

### DIFF
--- a/packages/cascader/src/main.vue
+++ b/packages/cascader/src/main.vue
@@ -243,7 +243,7 @@ export default {
     handlePick(value, close = true) {
       this.currentValue = value;
       this.$emit('input', value);
-      this.$emit('change', value);
+      this.$emit('change', value, this.menu.options[0].__IS__FLAT__OPTIONS);
 
       if (close) {
         this.menuVisible = false;


### PR DESCRIPTION
Add a 2nd parameter for change event to distinguish filtered-list-based change from cascaded-poppers-based change.

This is a new feature to satisfy the requirements 1 and 2 from a post of SegmentFault.com.

![image](https://user-images.githubusercontent.com/3956876/29425660-a6ecc358-83b6-11e7-8650-35fb3c5623b9.png)

Currently the 2nd requirement can't be satisfied.

My reply to the post:

![image](https://user-images.githubusercontent.com/3956876/29425818-30c40334-83b7-11e7-9e9a-238362ff5465.png)

Please make sure these boxes are checked before submitting your PR, thank you!

* [*] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [*] Make sure you are merging your commits to `dev` branch.
* [*] Add some descriptions and refer relative issues for you PR.
